### PR TITLE
configure drawerTitle/drawButtonTitle from config

### DIFF
--- a/backend/mapservice/App_Data/oversiktsplan.json
+++ b/backend/mapservice/App_Data/oversiktsplan.json
@@ -661,6 +661,8 @@
         },
         "enablePrint": true,
         "documentOnStart": "utgangspunkter",
+        "drawerTitle": "Översiktsplan",
+        "drawerButtonTitle": "Meny",
         "target": "hidden",
         "showScrollButtonLimit": 400,
         "dynamicImportUrls": {

--- a/new-client/src/plugins/documenthandler/documenthandler.js
+++ b/new-client/src/plugins/documenthandler/documenthandler.js
@@ -83,12 +83,12 @@ class DocumentHandler extends React.PureComponent {
   };
 
   addDrawerToggleButton = () => {
-    const { app } = this.props;
+    const { app, options } = this.props;
     app.globalObserver.publish("core.addDrawerToggleButton", {
       value: "menu",
       ButtonIcon: MenuBook,
-      caption: "Översiktsplan",
-      drawerTitle: "Översiktsplan",
+      caption: options.drawerButtonTitle || "Meny",
+      drawerTitle: options.drawerTitle || "Översiktsplan",
       order: 100,
       renderDrawerContent: this.renderDrawerContent,
     });


### PR DESCRIPTION
Allow drawerTitle and drawButton title for documenthandler to be configured from config. Default to 'Översiktsplan' and 'Meny'.