### PR TITLE
Changes to document table of content toggle behaviour

### DIFF
--- a/new-client/src/plugins/documenthandler/documentWindow/DocumentViewer.js
+++ b/new-client/src/plugins/documenthandler/documentWindow/DocumentViewer.js
@@ -105,6 +105,9 @@ class DocumentViewer extends React.PureComponent {
   componentDidUpdate = (prevProps) => {
     if (prevProps.activeDocument !== this.props.activeDocument) {
       this.scrollToTop();
+      this.setState({
+        expandedTableOfContents: expandedTocOnStart(this.props),
+      });
     }
   };
 

--- a/new-client/src/plugins/documenthandler/documentWindow/TableOfContents.js
+++ b/new-client/src/plugins/documenthandler/documentWindow/TableOfContents.js
@@ -144,13 +144,9 @@ class TableOfContents extends React.PureComponent {
     } = this.props;
 
     return (
-      <Grid
-        role="button"
-        onClick={toggleCollapse}
-        className={classes.tableOfContents}
-        container
-      >
+      <Grid role="button" className={classes.tableOfContents} container>
         <Grid
+          onClick={toggleCollapse}
           xs={12}
           alignItems="center"
           justify="space-between"


### PR DESCRIPTION
- When changing to a new document, table of content toggle status is based on that documents config, not on the toggling done in the previous document.

- Clicking on an item in the table of contents will no longer toggle the content menu. 